### PR TITLE
Support for the 9000rpm Clusters

### DIFF
--- a/src/app/dataset/src/dataset.cpp
+++ b/src/app/dataset/src/dataset.cpp
@@ -2,7 +2,7 @@
 #include "os_console.hpp"
 namespace app
 {
-    const uint32_t Dataset::cu32_version_number = 102u;
+    const uint32_t Dataset::cu32_version_number = 101u;
 
     int32_t Dataset::write_dataset(midware::NonvolatileDataHandler &o_nonvolatile_data_handler)
     {
@@ -192,7 +192,8 @@ namespace app
         // for speed conversion
         //m_u32_input_pulses_per_kmph_mHz = 4200u; // for testing direct feedback only (input pin connected to output pin)
         m_u32_input_pulses_per_kmph_mHz = 700u;
-        m_u32_output_pulses_per_kmph_mHz = 2800u; //4200u;
+        m_u32_output_pulses_per_kmph_mHz = 2800u; // Use this value for the 9000rpm digital cluster
+        //m_u32_output_pulses_per_kmph_mHz = 4200u; // Use this value for the 8000rpm digital cluster
         m_u32_dac_out_amplifying_factor = 2000u;
 
         m_u32_read_dataset_version_no = Dataset::cu32_version_number;

--- a/src/app/dataset/src/dataset.cpp
+++ b/src/app/dataset/src/dataset.cpp
@@ -2,7 +2,7 @@
 #include "os_console.hpp"
 namespace app
 {
-    const uint32_t Dataset::cu32_version_number = 101u;
+    const uint32_t Dataset::cu32_version_number = 102u;
 
     int32_t Dataset::write_dataset(midware::NonvolatileDataHandler &o_nonvolatile_data_handler)
     {
@@ -192,7 +192,7 @@ namespace app
         // for speed conversion
         //m_u32_input_pulses_per_kmph_mHz = 4200u; // for testing direct feedback only (input pin connected to output pin)
         m_u32_input_pulses_per_kmph_mHz = 700u;
-        m_u32_output_pulses_per_kmph_mHz = 4200u;
+        m_u32_output_pulses_per_kmph_mHz = 2800u; //4200u;
         m_u32_dac_out_amplifying_factor = 2000u;
 
         m_u32_read_dataset_version_no = Dataset::cu32_version_number;

--- a/src/app/speed_sensor_converter/inc/speed_sensor_converter.hpp
+++ b/src/app/speed_sensor_converter/inc/speed_sensor_converter.hpp
@@ -24,6 +24,13 @@ namespace app
         OUTPUT_MODE_REPLAY
     };
 
+    /** The type of speed sensor used in the vehicle */
+    enum SpeedSensorVariant
+    {
+        SPEED_SENSOR_8000RPM,
+        SPEED_SENSOR_9000RPM
+    };
+    
     /** The PWM IC is switched to a different prescaler, depending on the vehicle speed.
      *
      */
@@ -113,6 +120,11 @@ namespace app
         drivers::GenericPWM_IC* m_p_output_pwm_input_capture;
 
         std::atomic<SpeedOutputMode> m_en_current_speed_output_mode;
+
+        /** What kind of variant of speed sensor is installed in this vehicle. This
+         * has an impact on the signal shape (PWM and duty cycle).
+         */
+        SpeedSensorVariant m_en_speed_sensor_variant;
 
         /**
          * The manually set vehicle speed in meter/hour. Only valid if OUTPUT_MODE_MANUAL is set.

--- a/src/app/speed_sensor_converter/inc/speed_sensor_converter.hpp
+++ b/src/app/speed_sensor_converter/inc/speed_sensor_converter.hpp
@@ -24,12 +24,6 @@ namespace app
         OUTPUT_MODE_REPLAY
     };
 
-    /** The type of speed sensor used in the vehicle */
-    enum SpeedSensorVariant
-    {
-        SPEED_SENSOR_8000RPM,
-        SPEED_SENSOR_9000RPM
-    };
     
     /** The PWM IC is switched to a different prescaler, depending on the vehicle speed.
      *
@@ -120,11 +114,6 @@ namespace app
         drivers::GenericPWM_IC* m_p_output_pwm_input_capture;
 
         std::atomic<SpeedOutputMode> m_en_current_speed_output_mode;
-
-        /** What kind of variant of speed sensor is installed in this vehicle. This
-         * has an impact on the signal shape (PWM and duty cycle).
-         */
-        SpeedSensorVariant m_en_speed_sensor_variant;
 
         /**
          * The manually set vehicle speed in meter/hour. Only valid if OUTPUT_MODE_MANUAL is set.

--- a/src/app/speed_sensor_converter/inc/speed_sensor_converter.hpp
+++ b/src/app/speed_sensor_converter/inc/speed_sensor_converter.hpp
@@ -10,7 +10,6 @@
 #include "generic_pwm_ic.hpp"
 #include "replay_curve.hpp"
 
-
 /* Number of PWM Input Capture readings to be buffered */
 #define SPEED_SENSOR_READINGS_BUFFER_LENGTH 10
 
@@ -24,7 +23,6 @@ namespace app
         OUTPUT_MODE_REPLAY
     };
 
-    
     /** The PWM IC is switched to a different prescaler, depending on the vehicle speed.
      *
      */
@@ -87,13 +85,12 @@ namespace app
         /** Returns the current vehicle speed in m/h, as read from the sensor */
         uint32_t get_current_vehicle_speed() const;
         
-        
-        
         uint32_t get_input_pulses_per_kmph_in_mili_hertz() const;
+        
         void set_input_pulses_per_kmph_in_mili_hertz(uint32_t value);
-        
-        
+
         uint32_t get_output_pulses_per_kmph_in_mili_hertz() const;
+        
         void set_output_pulses_per_kmph_in_mili_hertz(uint32_t value);
 
         /** callback executed when the PWM IC reads a frequency */

--- a/src/app/speed_sensor_converter/src/speed_sensor_converter.cpp
+++ b/src/app/speed_sensor_converter/src/speed_sensor_converter.cpp
@@ -48,7 +48,6 @@ namespace app
                 uint32_t u32_input_pulses_per_kmph_mHz,
                 uint32_t u32_output_pulses_per_kmph_mHz)
     : m_p_output_pwm(p_output_pwm), m_p_output_pwm_input_capture(p_output_pwm_input_capture),
-      m_en_speed_sensor_variant(SPEED_SENSOR_9000RPM),
       m_en_current_speed_output_mode(OUTPUT_MODE_CONVERSION),
       m_i32_manual_speed(0), 
       m_u32_current_vehicle_speed_mph(0u),
@@ -487,29 +486,6 @@ namespace app
         {
             m_u32_new_output_frequency_mHz = i32_set_speed * m_u32_output_pulses_per_kmph_mHz;
             uint16_t duty_cycle = 500u; // 50%
-
-            if (SPEED_SENSOR_9000RPM == m_en_speed_sensor_variant)
-            {
-                /* for the 9k rpm cluster, the duty cycle is not 50/50, but is depending
-                 * on the frequency. The low duration is basically always 0.5ms.
-                 * Resulting unit should be ms, that's why *1000, and the frequency is
-                 * given in milihertz, therefore another 1000.
-                 */
-                const uint32_t total_duration_in_ms = 1000 * 1000 /  m_u32_new_output_frequency_mHz;
-                if (0 != total_duration_in_ms)
-                {
-                    duty_cycle = 500 / total_duration_in_ms; // 0.5ms
-
-                    if (duty_cycle >= 1000)
-                    {
-                        ExceptionHandler_handle_exception(EXCP_MODULE_SPEED_SENSOR_CONVERTER,
-                                EXCP_TYPE_SPEED_SENSOR_CONVERTER_VALID_SPEED_RANGE_EXCEEEDED,
-                                false, __FILE__, __LINE__, static_cast<uint32_t>(duty_cycle));
-                        duty_cycle = 100u;
-                    }
-                }
-            }
-
             m_p_output_pwm->set_duty_cycle(duty_cycle);
 
             

--- a/src/app/speed_sensor_converter/src/speed_sensor_converter.cpp
+++ b/src/app/speed_sensor_converter/src/speed_sensor_converter.cpp
@@ -488,7 +488,6 @@ namespace app
             uint16_t duty_cycle = 500u; // 50%
             m_p_output_pwm->set_duty_cycle(duty_cycle);
 
-            
             // change the pwm frequency on the output side
             m_p_output_pwm->set_frequency(m_u32_new_output_frequency_mHz);
         }

--- a/src/app/speed_sensor_converter/src/speed_sensor_converter.cpp
+++ b/src/app/speed_sensor_converter/src/speed_sensor_converter.cpp
@@ -48,6 +48,7 @@ namespace app
                 uint32_t u32_input_pulses_per_kmph_mHz,
                 uint32_t u32_output_pulses_per_kmph_mHz)
     : m_p_output_pwm(p_output_pwm), m_p_output_pwm_input_capture(p_output_pwm_input_capture),
+      m_en_speed_sensor_variant(SPEED_SENSOR_9000RPM),
       m_en_current_speed_output_mode(OUTPUT_MODE_CONVERSION),
       m_i32_manual_speed(0), 
       m_u32_current_vehicle_speed_mph(0u),
@@ -485,6 +486,33 @@ namespace app
         else
         {
             m_u32_new_output_frequency_mHz = i32_set_speed * m_u32_output_pulses_per_kmph_mHz;
+            uint16_t duty_cycle = 500u; // 50%
+
+            if (SPEED_SENSOR_9000RPM == m_en_speed_sensor_variant)
+            {
+                /* for the 9k rpm cluster, the duty cycle is not 50/50, but is depending
+                 * on the frequency. The low duration is basically always 0.5ms.
+                 * Resulting unit should be ms, that's why *1000, and the frequency is
+                 * given in milihertz, therefore another 1000.
+                 */
+                const uint32_t total_duration_in_ms = 1000 * 1000 /  m_u32_new_output_frequency_mHz;
+                if (0 != total_duration_in_ms)
+                {
+                    duty_cycle = 500 / total_duration_in_ms; // 0.5ms
+
+                    if (duty_cycle >= 1000)
+                    {
+                        ExceptionHandler_handle_exception(EXCP_MODULE_SPEED_SENSOR_CONVERTER,
+                                EXCP_TYPE_SPEED_SENSOR_CONVERTER_VALID_SPEED_RANGE_EXCEEEDED,
+                                false, __FILE__, __LINE__, static_cast<uint32_t>(duty_cycle));
+                        duty_cycle = 100u;
+                    }
+                }
+            }
+
+            m_p_output_pwm->set_duty_cycle(duty_cycle);
+
+            
             // change the pwm frequency on the output side
             m_p_output_pwm->set_frequency(m_u32_new_output_frequency_mHz);
         }

--- a/src/drivers/pwm/inc/generic_pwm.hpp
+++ b/src/drivers/pwm/inc/generic_pwm.hpp
@@ -14,7 +14,7 @@ namespace drivers
         virtual void set_frequency(uint32_t u32_frequency_mhz) = 0;
 
         /** Function to set the duty cycle of the PWM */
-        virtual void set_duty_cycle(uint32_t u32_duty_cycle) = 0;
+        virtual void set_duty_cycle(uint16_t u16_duty_cycle) = 0;
     };
 
 }

--- a/src/drivers/pwm/inc/stm32_pwm.hpp
+++ b/src/drivers/pwm/inc/stm32_pwm.hpp
@@ -20,7 +20,7 @@ namespace drivers
         /** Sets the frequency. Unit is milli hertz */
         virtual void set_frequency(uint32_t u32_frequency_millihertz);
 
-        virtual void set_duty_cycle(uint32_t u32_duty_cycle);
+        virtual void set_duty_cycle(uint16_t u16_duty_cycle);
 
     private:
         int32_t calculate_prescaler_value(uint32_t u32_frequency_mhz) const;
@@ -31,7 +31,7 @@ namespace drivers
         /** Configures the given GPIO pin as high (used for frequency 0) */
         int32_t configure_gpio_as_high();
 
-        int32_t reconfigure_pwm(uint32_t u32_frequency, uint32_t u32_duty_cycle);
+        int32_t reconfigure_pwm(uint32_t u32_frequency, uint16_t u16_duty_cycle);
 
 #ifdef HAL_TIM_MODULE_ENABLED
         /* Timer handler declaration */
@@ -44,9 +44,11 @@ namespace drivers
 
         uint32_t u32_timer_value;
 
-        // currently configured frequency
+        /// currently configured frequency
         uint32_t m_u32_configured_frequency_millihertz;
 
+		/// currently configured duty cycle (in % * 10).
+		uint16_t m_u16_configured_duty_cycle;
         GPIO_TypeDef* m_pt_gpio_block;
         uint16_t m_u16_gpio_pin;
 

--- a/src/drivers/pwm/src/stm32_pwm.cpp
+++ b/src/drivers/pwm/src/stm32_pwm.cpp
@@ -252,11 +252,9 @@ namespace drivers
         }
     }
 
-	void STM32PWM::set_duty_cycle(uint16_t u16_duty_cycle)
-	{
-	    m_u16_configured_duty_cycle = u16_duty_cycle;
-
-		// TODO do not update for now, this will be done at some later stage.
-	}
-
+    void STM32PWM::set_duty_cycle(uint16_t u16_duty_cycle)
+    {
+        m_u16_configured_duty_cycle = u16_duty_cycle;
+        // TODO do not update for now, this will be done at some later stage.
+    }
 }

--- a/src/drivers/pwm/src/stm32_pwm.cpp
+++ b/src/drivers/pwm/src/stm32_pwm.cpp
@@ -9,6 +9,7 @@ namespace drivers
             GPIO_TypeDef* pt_gpio_block, uint16_t u16_gpio_pin)
     : m_u32_timer_channel(u32_timer_channel),
       m_u32_configured_frequency_millihertz(123u), // set a random initial value, is set to 0 later
+      m_u16_configured_duty_cycle(500u), // set to 50% initially
       m_pt_gpio_block(pt_gpio_block),
       m_u16_gpio_pin(u16_gpio_pin)
     {
@@ -109,9 +110,9 @@ namespace drivers
         return 0;
     }
 
-    int32_t STM32PWM::reconfigure_pwm(uint32_t u32_frequency, uint32_t u32_duty_cycle)
+    int32_t STM32PWM::reconfigure_pwm(uint32_t u32_frequency, uint16_t u16_duty_cycle)
     {
-        if (0 == u32_frequency || u32_duty_cycle > 1000)
+        if (0 == u32_frequency || u16_duty_cycle > 1000u)
         {
             return -1;
         }
@@ -196,7 +197,7 @@ namespace drivers
         sConfig.OCIdleState  = TIM_OCIDLESTATE_RESET;
 
         /* Set the pulse value for channel 1 */
-        sConfig.Pulse = u32_timer_value * u32_duty_cycle / 1000;
+        sConfig.Pulse = u32_timer_value * static_cast<uint32_t>(u16_duty_cycle) / 1000;
         if (HAL_TIM_PWM_ConfigChannel(&o_timer_handle, &sConfig, m_u32_timer_channel) != HAL_OK)
             {
             /* Configuration Error */
@@ -240,7 +241,7 @@ namespace drivers
             HAL_TIM_PWM_Stop(&o_timer_handle, m_u32_timer_channel);  // Stop PWM
             if (0 != u32_frequency_mhz)
             {
-                reconfigure_pwm(u32_frequency_mhz, 500); // re-initialize the Timer2 with 50% duty cycle
+                reconfigure_pwm(u32_frequency_mhz, m_u16_configured_duty_cycle); // re-initialize the Timer2
             }
             else
             {
@@ -251,8 +252,11 @@ namespace drivers
         }
     }
 
-    void STM32PWM::set_duty_cycle(uint32_t u32_duty_cycle)
-    {
-        // not supported at the moment
-    }
+	void STM32PWM::set_duty_cycle(uint16_t u16_duty_cycle)
+	{
+	    m_u16_configured_duty_cycle = u16_duty_cycle;
+
+		// TODO do not update for now, this will be done at some later stage.
+	}
+
 }


### PR DESCRIPTION
- The 9k rpm clusters use 16 pulses per rotation instead of 24, and use
  PWM.